### PR TITLE
Hotfix API fetch

### DIFF
--- a/backend-and-api/src/main/resources/META-INF/MANIFEST.MF
+++ b/backend-and-api/src/main/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Main-Class: com.example.backendandapi.BackendAndApiApplication
+

--- a/frontend/src/components/account-create-form/AccountCreateForm.js
+++ b/frontend/src/components/account-create-form/AccountCreateForm.js
@@ -23,7 +23,7 @@ const AccountCreateForm = () => {
     };
 
     const createAccountRequest = () => {
-        fetch(`http://${INTERNAL_IP}:8080/api/account/create`, {
+        fetch(`http://${INTERNAL_IP || 'localhost'}:8080/api/account/create`, {
             method: "PUT",
             headers: {
                 "Content-Type": "application/json"

--- a/frontend/src/components/account-details/AccountDetails.js
+++ b/frontend/src/components/account-details/AccountDetails.js
@@ -31,7 +31,7 @@ const AccountDetails = ({ username }) => {
     }
 
     const modifyAccount = () => {
-        fetch(`http://${INTERNAL_IP}:8080/api/account/edit`, {
+        fetch(`http://${INTERNAL_IP || 'localhost'}:8080/api/account/edit`, {
             method: "POST",
             headers: {
                 "Content-Type": "application/json"
@@ -61,7 +61,7 @@ const AccountDetails = ({ username }) => {
 
    useEffect(() => {
     const requestAccount = () => {
-        fetch(`http://${INTERNAL_IP}:8080/api/account?username=${username}`)
+        fetch(`http://${INTERNAL_IP || 'localhost'}:8080/api/account?username=${username}`)
         .then(response => response.json())
         .then(data => {
             setAccount(data);

--- a/frontend/src/components/change-password-form/ChangePasswordForm.js
+++ b/frontend/src/components/change-password-form/ChangePasswordForm.js
@@ -29,7 +29,7 @@ const ChangePasswordForm = ({ username }) => {
     };
 
     const modifyAccount = () => {
-        fetch(`http://${INTERNAL_IP}:8080/api/account/edit`, {
+        fetch(`http://${INTERNAL_IP || 'localhost'}:8080/api/account/edit`, {
             method: "POST",
             headers: {
                 "Content-Type": "application/json"

--- a/frontend/src/components/login-form/LoginForm.js
+++ b/frontend/src/components/login-form/LoginForm.js
@@ -29,7 +29,7 @@ const LoginForm = () => {
     };
 
     const loginRequest = () => {
-        fetch(`http://${INTERNAL_IP}:8080/api/account/login`, {
+        fetch(`http://${INTERNAL_IP || 'localhost'}:8080/api/account/login`, {
             method: "POST",
             headers: {
                 "Content-Type": "application/json"


### PR DESCRIPTION
## Hotfix API fetch
Solved an issue from the frontend where the server couldn't make a API request if there was no internal IP provided

## Details of the issue
In `CreateAccountForm.js`, `AccountDetails.js`, `ChangePasswordForm.js` and `LoginForm.js` the functions responsible for making the API request would make a request to the internal IP(provided as an environment variable) and if the IP wasn't provided the variable would be considered `undefined` and thus, making an API request to an invalid address

## Fix
Added to option to make a request to the API through either the internal IP or by accessing `localhost` if the internal IP was not provided